### PR TITLE
feat: enhance marker card and balloon

### DIFF
--- a/app.js
+++ b/app.js
@@ -105,7 +105,23 @@
   function markerBalloonHTML(m){
     const dateStr = m.created_at ? new Date(m.created_at).toLocaleString('ru-RU') : '';
     const author = m.is_anon ? 'Аноним' : (m.author || '?');
-    return `<div class="marker-card"><div>${escapeHtml(m.description||'')}</div><div class="meta">${author}${dateStr ? ' • ' + dateStr : ''}</div></div>`;
+    const title = TYPES.find(tt => tt.key === m.type)?.title || '';
+    const media = Array.isArray(m.media) ? m.media.map(u => {
+      const url = escapeHtml(String(u));
+      return url.match(/\.mp4$/) ? `<video src="${url}" controls></video>` : `<img src="${url}" alt=""/>`;
+    }).join('') : '';
+    const confirms = m.confirms || 0;
+    const comments = m.comments || 0;
+    return `
+      <div class="marker-card">
+        <div class="hdr">${escapeHtml(title)}</div>
+        <div class="body">
+          <div>${escapeHtml(m.description||'')}</div>
+          ${media ? `<div class="media">${media}</div>` : ''}
+          <div class="meta">${author}${dateStr ? ' • ' + dateStr : ''}</div>
+        </div>
+        <div class="feedback"><span>✅ ${confirms}</span><span>💬 ${comments}</span></div>
+      </div>`;
   }
 
   function setPreset(name){
@@ -278,7 +294,6 @@
     (items||[]).forEach(m => {
       const t = TYPES.find(tt => tt.key === m.type) || TYPES[0];
       const pm = new ymaps.Placemark([m.lat, m.lng], {
-        balloonContentHeader: `<strong>${t.title}</strong>`,
         balloonContentBody: markerBalloonHTML(m),
         hintContent: t.title
       }, markerIconFor(t.key));
@@ -332,7 +347,6 @@
       const draft = { description: (els.desc?.value||''), author: authorName, is_anon: isAnon, created_at: new Date().toISOString() };
 
       optimisticPm = new ymaps.Placemark(pickedPoint, {
-        balloonContentHeader: `<strong>${t.title}</strong>`,
         balloonContentBody: markerBalloonHTML(draft),
         hintContent: t.title
       }, markerIconFor(t.key));

--- a/styles.css
+++ b/styles.css
@@ -36,8 +36,13 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:system-ui,-appl
 .feed{padding:12px;display:flex;flex-direction:column;gap:10px}
 .card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:10px}
 .card .meta{font-size:12px;color:var(--muted)}
-.marker-card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:10px}
+.marker-card{background:var(--card);border:1px solid var(--line);border-radius:14px;box-shadow:0 4px 14px rgba(0,0,0,.2);overflow:hidden}
+.marker-card .hdr{background:var(--accent);color:#fff;padding:8px 12px;font-weight:700}
+.marker-card .body{padding:10px}
+.marker-card .media{margin-top:8px}
+.marker-card .media img,.marker-card .media video{width:100%;border-radius:10px;display:block}
 .marker-card .meta{margin-top:6px;font-size:12px;color:var(--muted)}
+.marker-card .feedback{display:flex;gap:12px;padding:8px 10px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}
 .profile{padding:16px}
 .placeholder{padding:20px;text-align:center;color:var(--muted)}
 /* modal */


### PR DESCRIPTION
## Summary
- style marker card with accent header, media block and feedback row
- render marker balloon with title, media, meta and feedback counters
- simplify placemark balloon data

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_6896602995cc833280cb8238d1d93700