### PR TITLE
Add marker title field

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,6 +33,7 @@
     onb: $("#onb"),
     modal: $("#modal"),
     types: $("#types"),
+    title: $("#title"),
     desc: $("#desc"),
     dur: $("#dur"),
     useHere: $("#useHere"),
@@ -105,7 +106,7 @@
   function markerBalloonHTML(m){
     const dateStr = m.created_at ? new Date(m.created_at).toLocaleString('ru-RU') : '';
     const author = m.is_anon ? 'Аноним' : (m.author || '?');
-    return `<div class="marker-card"><div>${escapeHtml(m.description||'')}</div><div class="meta">${author}${dateStr ? ' • ' + dateStr : ''}</div></div>`;
+    return `<div class="marker-card">${m.title ? `<div style="font-weight:600">${escapeHtml(m.title)}</div>` : ''}<div>${escapeHtml(m.description||'')}</div><div class="meta">${author}${dateStr ? ' • ' + dateStr : ''}</div></div>`;
   }
 
   function setPreset(name){
@@ -329,7 +330,7 @@
       const t = TYPES.find(tt => tt.key === selectedType.key) || TYPES[0];
       const isAnon = !!els.anon?.checked;
       const authorName = isAnon ? '' : (tg?.initDataUnsafe?.user?.username || tg?.initDataUnsafe?.user?.first_name || "anon");
-      const draft = { description: (els.desc?.value||''), author: authorName, is_anon: isAnon, created_at: new Date().toISOString() };
+      const draft = { title: (els.title?.value||''), description: (els.desc?.value||''), author: authorName, is_anon: isAnon, created_at: new Date().toISOString() };
 
       optimisticPm = new ymaps.Placemark(pickedPoint, {
         balloonContentHeader: `<strong>${t.title}</strong>`,
@@ -345,6 +346,7 @@
         type: selectedType.key,
         lat: pickedPoint[0],
         lng: pickedPoint[1],
+        title: (els.title?.value||"").trim(),
         description: (els.desc?.value||"").trim(),
         duration_min: Number(els.dur?.value||120),
         author: authorName,

--- a/code.gs
+++ b/code.gs
@@ -7,7 +7,7 @@ function bootstrap() {
   const ss = SpreadsheetApp.openById(SPREADSHEET_ID);
   let sh = ss.getSheetByName(SHEET_MARKERS);
   if (!sh) sh = ss.insertSheet(SHEET_MARKERS);
-  const headers = ["id","type","lat","lng","description","author","client_id","is_anon","created_at","expires_at"];
+  const headers = ["id","type","lat","lng","title","description","author","client_id","is_anon","created_at","expires_at"];
   sh.getRange(1,1,1,headers.length).setValues([headers]);
 }
 
@@ -73,11 +73,11 @@ function addMarker(data) {
   const sh = ss.getSheetByName(SHEET_MARKERS) || ss.insertSheet(SHEET_MARKERS);
 
   // гарантируем заголовки
-  const header = sh.getRange(1,1,1, sh.getLastColumn() || 10).getValues()[0];
+  const header = sh.getRange(1,1,1, sh.getLastColumn() || 11).getValues()[0];
   if (!header || header[0] !== 'id') {
     sh.clear();
-    sh.getRange(1,1,1,10).setValues([[
-      'id','type','lat','lng','description','author','client_id','is_anon','created_at','expires_at'
+    sh.getRange(1,1,1,11).setValues([[
+      'id','type','lat','lng','title','description','author','client_id','is_anon','created_at','expires_at'
     ]]);
   }
 
@@ -91,6 +91,7 @@ function addMarker(data) {
     String(data.type || ''),
     Number(data.lat || 0),
     Number(data.lng || 0),
+    String(data.title || ''),
     String(data.description || ''),
     String(data.author || ''),
     String(data.client_id || ''),
@@ -112,7 +113,7 @@ function listMarkers(lat, lng, radiusMeters) {
   const now = new Date();
 
   for (let i = 1; i < rows.length; i++) {
-    const [id, type, la, ln, description, author, client_id, isAnon, created, expires] = rows[i];
+    const [id, type, la, ln, title, description, author, client_id, isAnon, created, expires] = rows[i];
     if (!la || !ln) continue;
     if (expires && expires < now) continue; // истёкшие скрываем
 
@@ -120,7 +121,7 @@ function listMarkers(lat, lng, radiusMeters) {
     if (dkm * 1000 <= radiusMeters) {
       out.push({
         id, type, lat: la, lng: ln,
-        description, author, is_anon: isAnon, created_at: created, expires_at: expires
+        title, description, author, is_anon: isAnon, created_at: created, expires_at: expires
       });
     }
   }

--- a/index.html
+++ b/index.html
@@ -86,6 +86,8 @@
     <div class="grip"></div>
     <h3>Новая метка</h3>
     <div id="types" class="types"></div>
+    <label class="lbl">Заголовок</label>
+    <input id="title" maxlength="80" placeholder="Заголовок" />
     <label class="lbl">Комментарий</label>
     <textarea id="desc" maxlength="255" placeholder="Коротко: что происходит?"></textarea>
     <div class="row">


### PR DESCRIPTION
## Summary
- add title input to marker modal
- include title in marker API payload and display in balloons
- extend backend sheet with title column

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896612093e88332a5f96b8c85404a86