### PR TITLE
Add image upload support for markers

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,6 +38,7 @@ const els = {
   types: $("#types"),
   title: $("#title"),
   desc: $("#desc"),
+  photo: $("#photo"),
   dur: $("#dur"),
   useHere: $("#useHere"),
   pickOnMap: $("#pickOnMap"),

--- a/index.html
+++ b/index.html
@@ -91,6 +91,8 @@
     <input id="title" maxlength="80" placeholder="Заголовок" />
     <label class="lbl">Комментарий</label>
     <textarea id="desc" maxlength="255" placeholder="Коротко: что происходит?"></textarea>
+    <label class="lbl">Фото</label>
+    <input type="file" id="photo" accept="image/*" />
     <div class="row">
       <label class="lbl">Автоистечение</label>
       <input id="dur" type="number" min="5" max="720" value="120"/> <span class="muted">мин</span>

--- a/src/api.js
+++ b/src/api.js
@@ -78,7 +78,17 @@ export async function publishMarker(){
     const t = window.TYPES.find(tt => tt.key === window.selectedType.key) || window.TYPES[0];
     const isAnon = !!window.els.anon?.checked;
     const authorName = isAnon ? '' : (window.tg?.initDataUnsafe?.user?.username || window.tg?.initDataUnsafe?.user?.first_name || "anon");
-    const draft = { title: (window.els.title?.value||''), description: (window.els.desc?.value||''), author: authorName, is_anon: isAnon, created_at: new Date().toISOString() };
+    let photoData = '';
+    const file = window.els.photo?.files?.[0];
+    if (file) {
+      photoData = await new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+      });
+    }
+    const draft = { title: (window.els.title?.value||''), description: (window.els.desc?.value||''), author: authorName, is_anon: isAnon, created_at: new Date().toISOString(), image_url: photoData };
 
     optimisticPm = new ymaps.Placemark(window.pickedPoint, {
       balloonContentHeader: `<strong>${t.title}</strong>`,
@@ -100,6 +110,7 @@ export async function publishMarker(){
       author: authorName,
       client_id: window.tg?.initDataUnsafe?.user?.id || "",
       is_anon: isAnon,
+      photo: photoData,
       request_id
     };
 

--- a/src/map.js
+++ b/src/map.js
@@ -24,7 +24,8 @@ export function markerBalloonHTML(m){
   const dateStr = m.created_at ? new Date(m.created_at).toLocaleString('ru-RU') : '';
   const author = m.is_anon ? 'Аноним' : (m.author || '?');
   const rating = Number(m.rating || 0);
-  return `<div class="marker-card">${m.title ? `<div style="font-weight:600">${escapeHTML(m.title)}</div>` : ''}<div>${escapeHTML(m.description||'')}</div><div class="meta">${author}${dateStr ? ' • ' + dateStr : ''}</div><div class="meta">Рейтинг: ${rating}</div></div>`;
+  const img = m.image_url ? `<img src="${escapeHTML(m.image_url)}" class="marker-img" alt=""/>` : '';
+  return `<div class="marker-card">${m.title ? `<div style="font-weight:600">${escapeHTML(m.title)}</div>` : ''}${img}<div>${escapeHTML(m.description||'')}</div><div class="meta">${author}${dateStr ? ' • ' + dateStr : ''}</div><div class="meta">Рейтинг: ${rating}</div></div>`;
 }
 
 export function setPreset(name){


### PR DESCRIPTION
## Summary
- allow attaching a photo when creating a marker
- upload photo to backend and store image URL
- show photo inside marker balloon if present

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68966c1ff1348332a6d17945c065aac1