### PR TITLE
refactor: centralize escapeHTML helper

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@ import { loadTheme, saveTheme, applyTheme } from './src/theme.js';
 import { loadMapPrefs, saveMapPrefs, markerIconFor, markerBalloonHTML, setPreset, highlightActivePreset, applyMapPrefs, markCustomIfTweaked } from './src/map.js';
 import { fetchMarkers, publishMarker, confirmMarker } from './src/api.js';
 import { toast, openModal, closeModal, showOnbIfNeeded, buildTypes, renderProfile, loadFeed } from './src/ui.js';
+import { escapeHTML } from './src/utils.js';
 
 const tg = window.Telegram?.WebApp;
 if (tg) { try { tg.expand(); tg.MainButton.hide(); } catch(_){} }
@@ -9,14 +10,7 @@ window.tg = tg;
 
 const $ = (sel) => document.querySelector(sel);
 const on = (el, ev, fn, opts) => { if (el) el.addEventListener(ev, fn, opts||false); };
-window.escapeHTML = (text) =>
-  (text || "").replace(/[&<>"']/g, c => ({
-    "&": "&amp;",
-    "<": "&lt;",
-    ">": "&gt;",
-    '"': "&quot;",
-    "'": "&#39;"
-  })[c]);
+window.escapeHTML = escapeHTML;
 
 const els = {
   tabs: {

--- a/code.gs
+++ b/code.gs
@@ -3,16 +3,23 @@ const SPREADSHEET_ID = '1kthJTm6r27LFQdqL2HvlWkhWFknZgH4YpUye3AbuR0U';
 const SHEET_MARKERS  = 'markers';
 const PHOTOS_FOLDER_ID = 'YOUR_PHOTOS_FOLDER_ID';
 
-function escapeHTML(text) {
-  return String(text || '').replace(/[&<>"']/g, function(c) {
-    return ({
-      '&': '&amp;',
-      '<': '&lt;',
-      '>': '&gt;',
-      '"': '&quot;',
-      "'": '&#39;'
-    })[c];
-  });
+let escapeHTML;
+try {
+  // CommonJS: load shared utility
+  escapeHTML = require('./src/utils.js').escapeHTML;
+} catch (e) {
+  // Fallback for direct Apps Script execution - keep in sync with src/utils.js
+  escapeHTML = function(text) {
+    return String(text || '').replace(/[&<>"']/g, function(c) {
+      return ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;'
+      })[c];
+    });
+  };
 }
 
 // Создать лист и заголовки (один раз)

--- a/src/map.js
+++ b/src/map.js
@@ -1,3 +1,5 @@
+import { escapeHTML } from './utils.js';
+
 export function loadMapPrefs(){
   try { return JSON.parse(localStorage.getItem("map_prefs_v2")) || { type: "yandex#map", traffic: false, preset: "standard" }; }
   catch(_) { return { type: "yandex#map", traffic: false, preset: "standard" }; }

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,5 +1,6 @@
 import { saveTheme, loadTheme } from './theme.js';
 import { loadMapPrefs, saveMapPrefs, applyMapPrefs, setPreset, highlightActivePreset, markCustomIfTweaked } from './map.js';
+import { escapeHTML } from './utils.js';
 
 export function toast(msg, t=2200){ if(!window.els.toast) return; window.els.toast.textContent = msg; window.els.toast.classList.remove("hidden"); setTimeout(()=>window.els.toast.classList.add("hidden"), t); }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,14 @@
+export function escapeHTML(text) {
+  return (text || "").replace(/[&<>"']/g, c => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+  })[c]);
+}
+
+// CommonJS compatibility for server-side usage
+if (typeof module !== 'undefined') {
+  module.exports = { escapeHTML };
+}


### PR DESCRIPTION
## Summary
- add shared `escapeHTML` utility
- import helper in browser modules
- require helper in GAS backend with fallback

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689673cb31488332be7ec2495dd45cbe