### PR TITLE
Route API requests through PHP proxy and handle CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
    - откройте <https://script.google.com/>, создайте новый проект и вставьте содержимое `code.gs` (значение `PHOTOS_FOLDER_ID` уже указано: `1CDe78tk-Urh35r0GxMHPVDPt9I-dvvrU`);
    - при необходимости измените `SPREADSHEET_ID`;
    - через меню **Deploy → New deployment → Web app** получите URL веб‑приложения.
-4. Укажите полученный URL в `window.MARKER_CONFIG.GAS_ENDPOINT` и/или `server/config.php` (по умолчанию стоит `https://script.google.com/macros/s/AKfycbwhBNyiokWlf6ifcD7sG0oOhU_xFIQrGBW8ZBDpZa_PmyGdYlQ0HRN0Zqgrn2em6CgSWA/exec`).
-5. В `server/config.php` уже заданы `PHOTOS_FOLDER_ID` и список `MARKER_ALLOWED_ORIGINS` (`https://www.bazzarproject.ru`); замените при необходимости или задайте через одноимённые переменные окружения.
+4. В `window.MARKER_CONFIG.GAS_ENDPOINT` укажите путь к прокси, например `/server/api/marker_api.php` (его можно задать и через `server/config.php`).
+5. В `server/config.php` уже заданы `PHOTOS_FOLDER_ID` и список `MARKER_ALLOWED_ORIGINS` (`https://www.bazzarproject.ru,https://bazzarproject.ru,http://localhost:8000`); замените при необходимости или задайте через одноимённые переменные окружения.
 6. Запустите сервер, например: `php -S localhost:8000 -t server`.
 
 ### Примеры конфигурации и деплоя
@@ -26,7 +26,7 @@
 return [
     'gas_endpoint' => 'https://script.google.com/macros/s/AKfycbwhBNyiokWlf6ifcD7sG0oOhU_xFIQrGBW8ZBDpZa_PmyGdYlQ0HRN0Zqgrn2em6CgSWA/exec',
     'photos_folder_id' => '1CDe78tk-Urh35r0GxMHPVDPt9I-dvvrU',
-    'allowed_origins' => ['https://www.bazzarproject.ru']
+    'allowed_origins' => ['https://www.bazzarproject.ru','https://bazzarproject.ru','http://localhost:8000']
 ];
 ```
 
@@ -35,7 +35,7 @@ return [
 ```
 export MARKER_GAS_ENDPOINT="https://script.google.com/macros/s/AKfycbwhBNyiokWlf6ifcD7sG0oOhU_xFIQrGBW8ZBDpZa_PmyGdYlQ0HRN0Zqgrn2em6CgSWA/exec"
 export PHOTOS_FOLDER_ID="1CDe78tk-Urh35r0GxMHPVDPt9I-dvvrU"
-export MARKER_ALLOWED_ORIGINS="https://www.bazzarproject.ru"
+export MARKER_ALLOWED_ORIGINS="https://www.bazzarproject.ru,https://bazzarproject.ru,http://localhost:8000"
 php -S localhost:8000 -t server
 RSYNC_DEST=user@host:/var/www/marker-webapp ./deploy.sh
 ```

--- a/code.gs
+++ b/code.gs
@@ -22,6 +22,17 @@ try {
   };
 }
 
+function withCors(out){
+  return out
+    .setHeader('Access-Control-Allow-Origin', '*')
+    .setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS')
+    .setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}
+
+function doOptions(e){
+  return withCors(ContentService.createTextOutput('')); 
+}
+
 // Создать лист и заголовки (один раз)
 function bootstrap() {
   const ss = SpreadsheetApp.openById(SPREADSHEET_ID);
@@ -42,25 +53,25 @@ function doGet(e) {
       const radius = parseInt(e.parameter.radius || '5000', 10);
       const markers = listMarkers(lat, lng, radius);
 
-      return ContentService
+      return withCors(ContentService
         .createTextOutput(JSON.stringify({ ok: true, markers }))
-        .setMimeType(ContentService.MimeType.JSON);
+        .setMimeType(ContentService.MimeType.JSON));
     }
 
     if (action === 'ping') {
-      return ContentService
+      return withCors(ContentService
         .createTextOutput(JSON.stringify({ ok: true, pong: true }))
-        .setMimeType(ContentService.MimeType.JSON);
+        .setMimeType(ContentService.MimeType.JSON));
     }
 
-    return ContentService
+    return withCors(ContentService
       .createTextOutput(JSON.stringify({ ok: false, error: 'unknown_action' }))
-      .setMimeType(ContentService.MimeType.JSON);
+      .setMimeType(ContentService.MimeType.JSON));
 
   } catch (err) {
-    return ContentService
+    return withCors(ContentService
       .createTextOutput(JSON.stringify({ ok: false, error: String(err) }))
-      .setMimeType(ContentService.MimeType.JSON);
+      .setMimeType(ContentService.MimeType.JSON));
   }
 }
 
@@ -71,26 +82,26 @@ function doPost(e) {
 
     if (action === 'add_marker') {
       const id = addMarker(body);
-      return ContentService
+      return withCors(ContentService
         .createTextOutput(JSON.stringify({ ok: true, id }))
-        .setMimeType(ContentService.MimeType.JSON);
+        .setMimeType(ContentService.MimeType.JSON));
     }
 
     if (action === 'confirm_marker') {
       const result = updateRating(String(body.id || ''), Number(body.delta || 1));
-      return ContentService
+      return withCors(ContentService
         .createTextOutput(JSON.stringify({ ok: true, rating: result.rating, confirmations: result.confirmations }))
-        .setMimeType(ContentService.MimeType.JSON);
+        .setMimeType(ContentService.MimeType.JSON));
     }
 
-    return ContentService
+    return withCors(ContentService
       .createTextOutput(JSON.stringify({ ok: false, error: 'unknown_action' }))
-      .setMimeType(ContentService.MimeType.JSON);
+      .setMimeType(ContentService.MimeType.JSON));
 
   } catch (err) {
-    return ContentService
+    return withCors(ContentService
       .createTextOutput(JSON.stringify({ ok: false, error: String(err) }))
-      .setMimeType(ContentService.MimeType.JSON);
+      .setMimeType(ContentService.MimeType.JSON));
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -117,12 +117,12 @@
 
 <div id="toast" class="toast hidden"></div>
 
-<script>
-  window.MARKER_CONFIG = {
-    GAS_ENDPOINT: "https://script.google.com/macros/s/AKfycbwhBNyiokWlf6ifcD7sG0oOhU_xFIQrGBW8ZBDpZa_PmyGdYlQ0HRN0Zqgrn2em6CgSWA/exec",
+  <script>
+    window.MARKER_CONFIG = {
+    GAS_ENDPOINT: "/server/api/marker_api.php",
     DEFAULT_RADIUS_METERS: 5000
   };
-</script>
+  </script>
 <script type="module" src="app.js?v=3.9"></script>
 </body>
 </html>

--- a/server/config.php
+++ b/server/config.php
@@ -3,7 +3,8 @@ return [
     // Origins allowed to access the API. Provide a comma-separated list in the
     // MARKER_ALLOWED_ORIGINS environment variable or edit this array.
     'allowed_origins' => array_filter(
-        array_map('trim', explode(',', getenv('MARKER_ALLOWED_ORIGINS') ?: 'https://www.bazzarproject.ru'))
+        array_map('trim', explode(',', getenv('MARKER_ALLOWED_ORIGINS')
+            ?: 'https://www.bazzarproject.ru,https://bazzarproject.ru,http://localhost:8000'))
     ),
     // Google Apps Script endpoint. Set MARKER_GAS_ENDPOINT or edit this value.
     'gas_endpoint' => getenv('MARKER_GAS_ENDPOINT') ?: 'https://script.google.com/macros/s/AKfycbwhBNyiokWlf6ifcD7sG0oOhU_xFIQrGBW8ZBDpZa_PmyGdYlQ0HRN0Zqgrn2em6CgSWA/exec',

--- a/src/api.js
+++ b/src/api.js
@@ -1,7 +1,10 @@
 import { markerIconFor, markerBalloonHTML } from './map.js';
 import { toast } from './ui.js';
 
-export function endpoint(){ return String(window.MARKER_CONFIG?.GAS_ENDPOINT || ""); }
+// All API calls go through a local proxy by default
+export function endpoint(){
+  return String(window.MARKER_CONFIG?.GAS_ENDPOINT || '/server/api/marker_api.php');
+}
 
 export async function fetchMarkers(){
   if (!window.map) return;


### PR DESCRIPTION
## Summary
- Default client API endpoint points to `/server/api/marker_api.php`
- Allow multiple origins in `server/config.php` and document proxy usage
- Add CORS headers and OPTIONS handler to `code.gs`

## Testing
- `node --check src/api.js`
- `php -l server/config.php`
- `node --check code.gs` *(fails: Unknown file extension)*

------
https://chatgpt.com/codex/tasks/task_e_689686b6f80c8332970fe982f3bdac25