### PR TITLE
feat: add custom marker balloon layout

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,4 +1,4 @@
-import { markerIconFor, markerBalloonHTML } from './map.js';
+import { markerIconFor, markerBalloonHTML, markerBalloonLayout } from './map.js';
 import { toast } from './ui.js';
 
 // All API calls go through a local proxy by default
@@ -28,12 +28,12 @@ export function renderMarkers(items){
   window.markersCollection.removeAll();
   (items||[]).forEach(m => {
     const t = window.TYPES.find(tt => tt.key === m.type) || window.TYPES[0];
+    const content = `<div class="marker-balloon__title"><strong>${t.title}</strong></div>${markerBalloonHTML(m)}`;
     const pm = new ymaps.Placemark([m.lat, m.lng], {
-      balloonContentHeader: `<strong>${t.title}</strong>`,
-      balloonContentBody: markerBalloonHTML(m),
+      balloonContent: content,
       hintContent: t.title,
       marker_id: m.id
-    }, markerIconFor(t.key));
+    }, { ...markerIconFor(t.key), balloonContentLayout: markerBalloonLayout, hideIconOnBalloonOpen: false });
     window.markersCollection.add(pm);
   });
 }
@@ -102,11 +102,11 @@ export async function publishMarker(){
     }
     const draft = { title: (window.els.title?.value||''), description: (window.els.desc?.value||''), author: authorName, is_anon: isAnon, created_at: new Date().toISOString(), image_url: photoData };
 
+    const draftContent = `<div class="marker-balloon__title"><strong>${t.title}</strong></div>${markerBalloonHTML(draft)}`;
     optimisticPm = new ymaps.Placemark(window.pickedPoint, {
-      balloonContentHeader: `<strong>${t.title}</strong>`,
-      balloonContentBody: markerBalloonHTML(draft),
+      balloonContent: draftContent,
       hintContent: t.title
-    }, markerIconFor(t.key));
+    }, { ...markerIconFor(t.key), balloonContentLayout: markerBalloonLayout, hideIconOnBalloonOpen: false });
     window.markersCollection.add(optimisticPm);
 
     const url = new URL(ep); url.searchParams.set("action","add_marker");

--- a/src/map.js
+++ b/src/map.js
@@ -30,6 +30,29 @@ export function markerBalloonHTML(m){
   return `<div class="marker-card">${m.title ? `<div style="font-weight:600">${escapeHTML(m.title)}</div>` : ''}${img}<div>${escapeHTML(m.description||'')}</div><div class="meta">${author}${dateStr ? ' • ' + dateStr : ''}</div><div class="meta">Рейтинг: ${rating}</div></div>`;
 }
 
+// Custom balloon layout with themed styles
+export const markerBalloonLayout = ymaps.templateLayoutFactory.createClass(
+  `<div class="marker-balloon">
+     <button class="marker-balloon__close" type="button">×</button>
+     $[properties.balloonContent]
+   </div>`, {
+    build: function(){
+      this.constructor.superclass.build.call(this);
+      this._closeHandler = this._onCloseClick.bind(this);
+      this._closeBtn = this.getParentElement().querySelector('.marker-balloon__close');
+      if (this._closeBtn) this._closeBtn.addEventListener('click', this._closeHandler);
+    },
+    clear: function(){
+      if (this._closeBtn && this._closeHandler) this._closeBtn.removeEventListener('click', this._closeHandler);
+      this.constructor.superclass.clear.call(this);
+    },
+    _onCloseClick: function(e){
+      e.preventDefault();
+      this.events.fire('userclose');
+    }
+  }
+);
+
 export function setPreset(name){
   let cfg;
   switch(name){

--- a/styles.css
+++ b/styles.css
@@ -38,6 +38,10 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:system-ui,-appl
 .card .meta{font-size:12px;color:var(--muted)}
 .marker-card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:10px}
 .marker-card .meta{margin-top:6px;font-size:12px;color:var(--muted)}
+.marker-balloon{position:relative;background:var(--card);border:1px solid var(--line);border-radius:14px;padding:10px;box-shadow:0 10px 30px rgba(0,0,0,.35)}
+.marker-balloon__close{position:absolute;top:4px;right:6px;background:transparent;border:none;color:var(--muted);font-size:16px;cursor:pointer}
+.marker-balloon__close:hover{color:var(--text)}
+.marker-balloon__title{margin-bottom:6px;font-weight:600}
 .profile{padding:16px}
 .placeholder{padding:20px;text-align:center;color:var(--muted)}
 /* modal */


### PR DESCRIPTION
## Summary
- add themed balloon layout for Yandex map markers
- render markers with new layout
- style custom balloon

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689688037ab48332a1d7b490905072c2