### PR TITLE
Simplify CORS helper for marker backend

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -27,10 +27,8 @@ try {
 }
 
 function withCors(out){
-  return out
-    .setHeader('Access-Control-Allow-Origin', '*')
-    .setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS')
-    .setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  out.setHeader('Access-Control-Allow-Origin', '*');
+  return out;
 }
 
 function doOptions(e){


### PR DESCRIPTION
## Summary
- simplify `withCors` to only set `Access-Control-Allow-Origin`
- ensure API handlers use the new CORS helper for responses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689733d108508332acb4b50bc8033191