### PR TITLE
Clarify GAS endpoint configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,9 @@
    - откройте <https://script.google.com/>, создайте новый проект и вставьте содержимое `code.gs` (значение `PHOTOS_FOLDER_ID` уже указано: `1CDe78tk-Urh35r0GxMHPVDPt9I-dvvrU`);
    - при необходимости измените `SPREADSHEET_ID`;
    - через меню **Deploy → New deployment → Web app** получите URL веб‑приложения.
-4. В `window.MARKER_CONFIG.GAS_ENDPOINT` оставьте `/server/api/marker_api.php` — клиент будет обращаться к локальному PHP‑прокси.
-5. Настоящий URL Google Apps Script указывается в `server/config.php` (ключ `gas_endpoint` или переменная окружения `MARKER_GAS_ENDPOINT`).
-6. В `server/config.php` уже заданы `PHOTOS_FOLDER_ID` и список `MARKER_ALLOWED_ORIGINS` (`https://www.bazzarproject.ru`); замените при необходимости или задайте через одноимённые переменные окружения.
-7. Запустите сервер, например: `php -S localhost:8000 -t server`.
-4. В `window.MARKER_CONFIG.GAS_ENDPOINT` укажите путь к веб-приложению Google Apps Script или прокси, например `https://script.google.com/macros/s/AKfycbyAl3VHgOygkgL6wt9OaG0_xMSZRg0j7kmfBlBeTlMVA6TkpwYAN0j61XggDLYwLqS0/exec` или `/server/api/marker_api.php` (его можно задать и через `server/config.php`).
-5. В `server/config.php` уже заданы `PHOTOS_FOLDER_ID` и список `MARKER_ALLOWED_ORIGINS` (`https://www.bazzarproject.ru,https://bazzarproject.ru,http://localhost:8000`); замените при необходимости или задайте через одноимённые переменные окружения.
+4. В файле `index.html` замените значение `window.MARKER_CONFIG.GAS_ENDPOINT` на полученный URL веб‑приложения или путь к прокси, например `/server/api/marker_api.php`.
+5. В `server/config.php` уже заданы `PHOTOS_FOLDER_ID` и список `MARKER_ALLOWED_ORIGINS` (`https://www.bazzarproject.ru`); замените при необходимости или задайте через одноимённые переменные окружения.
+6. Запустите сервер, например: `php -S localhost:8000 -t server`.
 
 
 ### Примеры конфигурации и деплоя

--- a/index.html
+++ b/index.html
@@ -120,17 +120,11 @@
 
 <script>
   window.MARKER_CONFIG = {
-    // Client requests go to the local PHP proxy which forwards to the
-    // actual Google Apps Script endpoint configured on the server.
-    GAS_ENDPOINT: "/server/api/marker_api.php",
-
-  <script>
-    window.MARKER_CONFIG = {
-    GAS_ENDPOINT: "https://script.google.com/macros/s/AKfycbyAl3VHgOygkgL6wt9OaG0_xMSZRg0j7kmfBlBeTlMVA6TkpwYAN0j61XggDLYwLqS0/exec",
-
+    // Replace GAS_ENDPOINT with your Google Apps Script URL or proxy path.
+    GAS_ENDPOINT: "https://script.google.com/macros/s/YOUR_DEPLOYMENT_ID/exec",
     DEFAULT_RADIUS_METERS: 5000
   };
-  </script>
+</script>
 <script type="module" src="app.js?v=3.9"></script>
 </body>
 </html>

--- a/src/api.js
+++ b/src/api.js
@@ -1,14 +1,21 @@
 import { markerIconFor, markerBalloonHTML, markerBalloonLayout } from './map.js';
 import { toast } from './ui.js';
 
-// All API calls go through a local proxy by default
+const EXPECTED_URL = 'https://script.google.com/macros/s/YOUR_DEPLOYMENT_ID/exec';
+
+// Return configured GAS endpoint or empty string if missing
 export function endpoint(){
-  return String(window.MARKER_CONFIG?.GAS_ENDPOINT || '/server/api/marker_api.php');
+  const ep = window.MARKER_CONFIG?.GAS_ENDPOINT;
+  if (!ep || ep.includes('YOUR_DEPLOYMENT_ID')){
+    console.warn(`GAS_ENDPOINT is not configured. Expected something like ${EXPECTED_URL}`);
+    return '';
+  }
+  return String(ep);
 }
 
 export async function fetchMarkers(){
   if (!window.map) return;
-  const ep = endpoint(); if (!ep) return toast("API не настроено");
+  const ep = endpoint(); if (!ep) return toast(`API не настроено. Укажите GAS_ENDPOINT, например: ${EXPECTED_URL}`);
   const center = window.map.getCenter(), radius = window.MARKER_CONFIG.DEFAULT_RADIUS_METERS;
   const url = new URL(ep); url.searchParams.set("action","list_markers"); url.searchParams.set("lat",center[0]); url.searchParams.set("lng",center[1]); url.searchParams.set("radius",radius);
   try {
@@ -57,7 +64,7 @@ export function hasDuplicateNearby(type, coords, meters=25, minutes=15){
 }
 
 export async function publishMarker(){
-  const ep = endpoint(); if (!ep) return toast("API не настроено");
+  const ep = endpoint(); if (!ep) return toast(`API не настроено. Укажите GAS_ENDPOINT, например: ${EXPECTED_URL}`);
   if (!window.selectedType) { toast("Выберите тип метки"); return; }
 
   if (!window.pickedPoint) {
@@ -152,7 +159,7 @@ export async function publishMarker(){
 }
 
 export async function confirmMarker(id, delta=1){
-  const ep = endpoint(); if (!ep) return toast("API не настроено");
+  const ep = endpoint(); if (!ep) return toast(`API не настроено. Укажите GAS_ENDPOINT, например: ${EXPECTED_URL}`);
   try {
     const url = new URL(ep); url.searchParams.set("action","confirm_marker");
     const res = await fetch(url.toString(), {


### PR DESCRIPTION
## Summary
- define `window.MARKER_CONFIG` before loading `app.js`
- add explicit GAS endpoint check with helpful hint
- document how to set `GAS_ENDPOINT`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689734a26a4c8332a019a72051f05d30