### PR TITLE
feat: make Yandex map key configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@
 ## Установка
 
 1. Установите PHP и клонируйте репозиторий.
-2. Ключ [Yandex Maps API](https://developer.tech.yandex.ru/) уже прописан в `index.html` (`79bead93-8713-4de9-9dac-484d3aa0980d`); при необходимости замените на свой.
+2. Получите ключ [Yandex Maps API](https://developer.tech.yandex.ru/) и укажите его:
+   - через поле `YA_MAPS_KEY` объекта `window.MARKER_CONFIG` в `index.html`,
+   - либо добавив мета‑тег `<meta name="ya-maps-key" content="ВАШ_КЛЮЧ">` в `<head>`.
+   Скрипт карт загрузится автоматически с указанным ключом.
 3. Разверните Google Apps Script:
    - откройте <https://script.google.com/>, создайте новый проект и вставьте содержимое `code.gs` (значение `PHOTOS_FOLDER_ID` уже указано: `1CDe78tk-Urh35r0GxMHPVDPt9I-dvvrU`);
    - при необходимости измените `SPREADSHEET_ID`;

--- a/app.js
+++ b/app.js
@@ -76,6 +76,14 @@ window.toast = toast;
 window.openModal = openModal;
 window.closeModal = closeModal;
 
+function loadYaMaps(cb){
+  const key = window.MARKER_CONFIG?.YA_MAPS_KEY || document.querySelector('meta[name="ya-maps-key"]')?.content;
+  const script = document.createElement('script');
+  script.src = 'https://api-maps.yandex.ru/2.1/?lang=ru_RU' + (key ? '&apikey=' + encodeURIComponent(key) : '');
+  script.onload = cb;
+  document.head.appendChild(script);
+}
+
 function initMap(){
   if (!window.ymaps) return;
   ymaps.ready(() => {
@@ -181,4 +189,4 @@ on(els.zoomOut, "click", ()=>{ if (window.map) window.map.setZoom(window.map.get
 applyTheme();
 showOnbIfNeeded();
 buildTypes();
-initMap();
+loadYaMaps(initMap);

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <title>Маркер — WebApp</title>
 <link rel="stylesheet" href="styles.css?v=3.9" />
 <script src="https://telegram.org/js/telegram-web-app.js"></script>
-<script src="https://api-maps.yandex.ru/2.1/?apikey=79bead93-8713-4de9-9dac-484d3aa0980d&lang=ru_RU"></script>
+<meta name="ya-maps-key" content="" />
 </head>
 <body>
 <div id="app">
@@ -122,6 +122,7 @@
   window.MARKER_CONFIG = {
     // Replace GAS_ENDPOINT with your Google Apps Script URL or proxy path.
     GAS_ENDPOINT: "https://script.google.com/macros/s/YOUR_DEPLOYMENT_ID/exec",
+    YA_MAPS_KEY: "",
     DEFAULT_RADIUS_METERS: 5000
   };
 </script>


### PR DESCRIPTION
## Summary
- load Yandex Maps API script using key from MARKER_CONFIG or meta tag
- document how to get and configure Yandex Maps API key

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689736e1a7cc83328d63abce1b916e01