### PR TITLE
Configure endpoints and defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,15 @@
 ## Установка
 
 1. Установите PHP и клонируйте репозиторий.
-2. Получите ключ [Yandex Maps API](https://developer.tech.yandex.ru/) и замените `YOUR_YANDEX_API_KEY` в теге подключения карт в `index.html`.
+2. Ключ [Yandex Maps API](https://developer.tech.yandex.ru/) уже прописан в `index.html` (`79bead93-8713-4de9-9dac-484d3aa0980d`); при необходимости замените на свой.
 3. Разверните Google Apps Script:
-   - откройте <https://script.google.com/>, создайте новый проект и вставьте содержимое `code.gs`;
-   - задайте `PHOTOS_FOLDER_ID` (ID папки Google Drive для загрузок) и при необходимости `SPREADSHEET_ID`;
+   - откройте <https://script.google.com/>, создайте новый проект и вставьте содержимое `code.gs` (значение `PHOTOS_FOLDER_ID` уже указано: `1CDe78tk-Urh35r0GxMHPVDPt9I-dvvrU`);
+   - при необходимости измените `SPREADSHEET_ID`;
    - через меню **Deploy → New deployment → Web app** получите URL веб‑приложения.
-4. Укажите полученный URL в `window.MARKER_CONFIG.GAS_ENDPOINT` или пропишите `gas_endpoint` в `server/config.php` для прокси `server/api/marker_api.php`.
-5. В `server/config.php` задайте `PHOTOS_FOLDER_ID` и список `MARKER_ALLOWED_ORIGINS` (можно через одноимённые переменные окружения).
-6. Запустите сервер, например: `php -S localhost:8000 -t server`.
+4. В `window.MARKER_CONFIG.GAS_ENDPOINT` оставьте `/server/api/marker_api.php` — клиент будет обращаться к локальному PHP‑прокси.
+5. Настоящий URL Google Apps Script указывается в `server/config.php` (ключ `gas_endpoint` или переменная окружения `MARKER_GAS_ENDPOINT`).
+6. В `server/config.php` уже заданы `PHOTOS_FOLDER_ID` и список `MARKER_ALLOWED_ORIGINS` (`https://www.bazzarproject.ru`); замените при необходимости или задайте через одноимённые переменные окружения.
+7. Запустите сервер, например: `php -S localhost:8000 -t server`.
 
 ### Примеры конфигурации и деплоя
 
@@ -24,18 +25,18 @@
 ```php
 <?php
 return [
-    'gas_endpoint' => 'https://script.google.com/macros/s/XXXXXXXX/exec',
-    'photos_folder_id' => '1AbCDeFgHiJ',
-    'allowed_origins' => ['https://example.com']
+    'gas_endpoint' => 'https://script.google.com/macros/s/AKfycbwhBNyiokWlf6ifcD7sG0oOhU_xFIQrGBW8ZBDpZa_PmyGdYlQ0HRN0Zqgrn2em6CgSWA/exec',
+    'photos_folder_id' => '1CDe78tk-Urh35r0GxMHPVDPt9I-dvvrU',
+    'allowed_origins' => ['https://www.bazzarproject.ru']
 ];
 ```
 
 Команды:
 
 ```
-export MARKER_GAS_ENDPOINT="https://script.google.com/macros/s/XXXXXXXX/exec"
-export PHOTOS_FOLDER_ID="1AbCDeFgHiJ"
-export MARKER_ALLOWED_ORIGINS="https://example.com,https://example.org"
+export MARKER_GAS_ENDPOINT="https://script.google.com/macros/s/AKfycbwhBNyiokWlf6ifcD7sG0oOhU_xFIQrGBW8ZBDpZa_PmyGdYlQ0HRN0Zqgrn2em6CgSWA/exec"
+export PHOTOS_FOLDER_ID="1CDe78tk-Urh35r0GxMHPVDPt9I-dvvrU"
+export MARKER_ALLOWED_ORIGINS="https://www.bazzarproject.ru"
 php -S localhost:8000 -t server
 RSYNC_DEST=user@host:/var/www/marker-webapp ./deploy.sh
 ```

--- a/code.gs
+++ b/code.gs
@@ -1,7 +1,7 @@
 /** Маркер — Google Apps Script backend (v2.2 без setHeader) */
 const SPREADSHEET_ID = '1kthJTm6r27LFQdqL2HvlWkhWFknZgH4YpUye3AbuR0U';
 const SHEET_MARKERS  = 'markers';
-const PHOTOS_FOLDER_ID = 'YOUR_PHOTOS_FOLDER_ID';
+const PHOTOS_FOLDER_ID = '1CDe78tk-Urh35r0GxMHPVDPt9I-dvvrU';
 
 let escapeHTML;
 try {

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <title>Маркер — WebApp</title>
 <link rel="stylesheet" href="styles.css?v=3.9" />
 <script src="https://telegram.org/js/telegram-web-app.js"></script>
-<script src="https://api-maps.yandex.ru/2.1/?apikey=YOUR_YANDEX_API_KEY&lang=ru_RU"></script>
+<script src="https://api-maps.yandex.ru/2.1/?apikey=79bead93-8713-4de9-9dac-484d3aa0980d&lang=ru_RU"></script>
 </head>
 <body>
 <div id="app">
@@ -119,7 +119,9 @@
 
 <script>
   window.MARKER_CONFIG = {
-    GAS_ENDPOINT: "https://your-domain.example.com/server/api/marker_api.php",
+    // Client requests go to the local PHP proxy which forwards to the
+    // actual Google Apps Script endpoint configured on the server.
+    GAS_ENDPOINT: "/server/api/marker_api.php",
     DEFAULT_RADIUS_METERS: 5000
   };
 </script>

--- a/server/config.php
+++ b/server/config.php
@@ -2,10 +2,12 @@
 return [
     // Origins allowed to access the API. Provide a comma-separated list in the
     // MARKER_ALLOWED_ORIGINS environment variable or edit this array.
-    'allowed_origins' => array_filter(array_map('trim', explode(',', getenv('MARKER_ALLOWED_ORIGINS') ?: ''))),
+    'allowed_origins' => array_filter(
+        array_map('trim', explode(',', getenv('MARKER_ALLOWED_ORIGINS') ?: 'https://www.bazzarproject.ru'))
+    ),
     // Google Apps Script endpoint. Set MARKER_GAS_ENDPOINT or edit this value.
-    'gas_endpoint' => getenv('MARKER_GAS_ENDPOINT') ?: '',
+    'gas_endpoint' => getenv('MARKER_GAS_ENDPOINT') ?: 'https://script.google.com/macros/s/AKfycbwhBNyiokWlf6ifcD7sG0oOhU_xFIQrGBW8ZBDpZa_PmyGdYlQ0HRN0Zqgrn2em6CgSWA/exec',
     // Google Drive folder for uploaded photos. Set PHOTOS_FOLDER_ID or edit this value.
-    'photos_folder_id' => getenv('PHOTOS_FOLDER_ID') ?: '',
+    'photos_folder_id' => getenv('PHOTOS_FOLDER_ID') ?: '1CDe78tk-Urh35r0GxMHPVDPt9I-dvvrU',
 ];
 


### PR DESCRIPTION
## Summary
- use bundled PHP proxy for Google Apps Script calls to avoid CORS issues
- clarify setup: client points to proxy while server config holds real GAS URL

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT)*
- `php -l server/config.php`
- `php -l server/api/marker_api.php`


------
https://chatgpt.com/codex/tasks/task_e_68966e75e9a483329173ea0592b26f4f