### PR TITLE
Configure keys via env vars and placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@
 ## Установка
 
 1. Установите PHP и клонируйте репозиторий.
-2. Укажите ключ Yandex Maps API:
-   - через поле `YA_MAPS_KEY` объекта `window.MARKER_CONFIG` в `index.html`,
-   - либо добавив мета‑тег `<meta name="ya-maps-key" content="ВАШ_КЛЮЧ">` в `<head>`.
-3. В `index.html` замените `window.MARKER_CONFIG.GAS_ENDPOINT` на URL веб‑приложения Google Apps Script или путь к прокси, например `/server/api/marker_api.php`.
-4. В `server/config.php` задайте `PHOTOS_FOLDER_ID` и список `MARKER_ALLOWED_ORIGINS` или используйте переменные окружения (см. ниже).
+2. Укажите ключ Yandex Maps API (в `index.html` установлен плейсхолдер `YOUR_YA_MAPS_KEY`):
+   - через поле `YA_MAPS_KEY` объекта `window.MARKER_CONFIG`,
+   - либо в мета‑теге `<meta name="ya-maps-key" content="ВАШ_КЛЮЧ">` в `<head>`.
+3. В `index.html` замените `window.MARKER_CONFIG.GAS_ENDPOINT` на URL веб‑приложения Google Apps Script или путь к прокси (например `/server/api/marker_api.php`).
+4. Задайте переменные окружения `MARKER_GAS_ENDPOINT`, `PHOTOS_FOLDER_ID` и `MARKER_ALLOWED_ORIGINS` (см. ниже) или измените их значения в `server/config.php`.
 5. Запустите сервер: `php -S localhost:8000 -t server`.
 
 ## Деплой Google Apps Script
@@ -35,6 +35,8 @@
 3. После копирования `escapeHTML` станет доступна в коде `code.gs` без изменений.
 
 ## Настройка переменных окружения
+
+Эти переменные используются `server/config.php` и `server/api/marker_api.php`.
 
 ```bash
 export MARKER_GAS_ENDPOINT="https://script.google.com/macros/s/AKfycbwhBNyiokWlf6ifcD7sG0oOhU_xFIQrGBW8ZBDpZa_PmyGdYlQ0HRN0Zqgrn2em6CgSWA/exec"

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <title>Маркер — WebApp</title>
 <link rel="stylesheet" href="styles.css?v=3.9" />
 <script src="https://telegram.org/js/telegram-web-app.js"></script>
-<meta name="ya-maps-key" content="" />
+<meta name="ya-maps-key" content="YOUR_YA_MAPS_KEY" />
 </head>
 <body>
 <div id="app">
@@ -122,7 +122,7 @@
   window.MARKER_CONFIG = {
     // Replace GAS_ENDPOINT with your Google Apps Script URL or proxy path.
     GAS_ENDPOINT: "https://script.google.com/macros/s/YOUR_DEPLOYMENT_ID/exec",
-    YA_MAPS_KEY: "",
+    YA_MAPS_KEY: "YOUR_YA_MAPS_KEY",
     DEFAULT_RADIUS_METERS: 5000
   };
 </script>

--- a/server/api/marker_api.php
+++ b/server/api/marker_api.php
@@ -1,6 +1,8 @@
 <?php
 $config = @include __DIR__ . '/../config.php';
-$allowed = $config['allowed_origins'] ?? [];
+$allowed = $config['allowed_origins'] ?? array_filter(
+    array_map('trim', explode(',', getenv('MARKER_ALLOWED_ORIGINS') ?: ''))
+);
 $origin = $_SERVER['HTTP_ORIGIN'] ?? '';
 if ($origin && (empty($allowed) || in_array($origin, $allowed, true))) {
   header("Access-Control-Allow-Origin: $origin");
@@ -12,7 +14,7 @@ header('Access-Control-Allow-Methods: GET,POST,OPTIONS');
 header('Access-Control-Allow-Headers: Content-Type');
 if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') { http_response_code(204); exit; }
 
-$gasEndpoint = $config['gas_endpoint'] ?? '';
+$gasEndpoint = $config['gas_endpoint'] ?? getenv('MARKER_GAS_ENDPOINT') ?: '';
 if (!$gasEndpoint) {
   http_response_code(500);
   header('Content-Type: application/json; charset=UTF-8');

--- a/server/config.php
+++ b/server/config.php
@@ -1,21 +1,15 @@
 <?php
+// Configuration values for the Marker API server.
+// Values are primarily sourced from environment variables so that secrets
+// are not committed to the repository.
 return [
-    // Origins allowed to access the API. Provide a comma-separated list in the
-    // MARKER_ALLOWED_ORIGINS environment variable or edit this array.
+    // Comma-separated list of origins allowed to access the API.
     'allowed_origins' => array_filter(
-
-        array_map('trim', explode(',', getenv('MARKER_ALLOWED_ORIGINS') ?: 'https://www.bazzarproject.ru'))
+        array_map('trim', explode(',', getenv('MARKER_ALLOWED_ORIGINS') ?: ''))
     ),
-    // Google Apps Script endpoint. Set MARKER_GAS_ENDPOINT or edit this value.
-    'gas_endpoint' => getenv('MARKER_GAS_ENDPOINT') ?: 'https://script.google.com/macros/s/AKfycbwhBNyiokWlf6ifcD7sG0oOhU_xFIQrGBW8ZBDpZa_PmyGdYlQ0HRN0Zqgrn2em6CgSWA/exec',
-
-        array_map('trim', explode(',', getenv('MARKER_ALLOWED_ORIGINS')
-            ?: 'https://www.bazzarproject.ru,https://bazzarproject.ru,http://localhost:8000'))
-    ),
-    // Google Apps Script endpoint. Set MARKER_GAS_ENDPOINT or edit this value.
-    'gas_endpoint' => getenv('MARKER_GAS_ENDPOINT') ?: 'https://script.google.com/macros/s/AKfycbyAl3VHgOygkgL6wt9OaG0_xMSZRg0j7kmfBlBeTlMVA6TkpwYAN0j61XggDLYwLqS0/exec',
-
-    // Google Drive folder for uploaded photos. Set PHOTOS_FOLDER_ID or edit this value.
-    'photos_folder_id' => getenv('PHOTOS_FOLDER_ID') ?: '1CDe78tk-Urh35r0GxMHPVDPt9I-dvvrU',
+    // Google Apps Script endpoint used by the proxy.
+    'gas_endpoint' => getenv('MARKER_GAS_ENDPOINT') ?: '',
+    // Google Drive folder for uploaded photos.
+    'photos_folder_id' => getenv('PHOTOS_FOLDER_ID') ?: '',
 ];
 


### PR DESCRIPTION
## Summary
- replace hard-coded Yandex Maps API key with placeholders read from window config or meta tag
- pull GAS endpoint and allowed origins from environment variables
- document key setup and env vars in README

## Testing
- `npm test`
- `php -l server/config.php`
- `php -l server/api/marker_api.php`


------
https://chatgpt.com/codex/tasks/task_e_68973e9872cc8332948793fa286f2b74