### PR TITLE
docs: reference shared escape util

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -6,7 +6,7 @@ const SHEET_MARKERS  = 'markers';
 const SHEET_USERS    = 'users';
 
 const PHOTOS_FOLDER_ID = '1CDe78tk-Urh35r0GxMHPVDPt9I-dvvrU';
-
+// escapeHTML is shared with the frontend and lives in src/utils.js
 const { escapeHTML } = require('./src/utils.js');
 
 function withCors(out){


### PR DESCRIPTION
## Summary
- note that escapeHTML comes from shared `src/utils.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68974174fba08332a95805206ae721f4