### PR TITLE
feat: share haversine util

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -6,8 +6,8 @@ const SHEET_MARKERS  = 'markers';
 const SHEET_USERS    = 'users';
 
 const PHOTOS_FOLDER_ID = '1CDe78tk-Urh35r0GxMHPVDPt9I-dvvrU';
-// escapeHTML is shared with the frontend and lives in src/utils.js
-const { escapeHTML } = require('./src/utils.js');
+// escapeHTML and haversine are shared with the frontend and live in src/utils.js
+const { escapeHTML, haversine } = require('./src/utils.js');
 
 function withCors(out){
   out.setHeader('Access-Control-Allow-Origin', '*');
@@ -244,7 +244,7 @@ function listMarkers(lat, lng, radiusMeters) {
     if (!la || !ln) continue;
     if (expires && expires < now) continue; // истёкшие скрываем
 
-    const dkm = haversine(lat, lng, la, ln);
+    const dkm = haversine([lat, lng], [la, ln]) / 1000;
     if (dkm * 1000 <= radiusMeters) {
       out.push({
         id, type, lat: la, lng: ln,
@@ -277,12 +277,3 @@ function updateRating(id, delta, confirmerId) {
   throw new Error('not_found');
 }
 
-// расстояние между точками (км)
-function haversine(lat1, lon1, lat2, lon2) {
-  const R = 6371; // km
-  const toRad = x => x * Math.PI / 180;
-  const dLat = toRad(lat2 - lat1);
-  const dLon = toRad(lon2 - lon1);
-  const a = Math.sin(dLat/2)**2 + Math.cos(toRad(lat1))*Math.cos(toRad(lat2))*Math.sin(dLon/2)**2;
-  return 2 * R * Math.asin(Math.sqrt(a));
-}

--- a/src/api.js
+++ b/src/api.js
@@ -1,5 +1,6 @@
 import { markerIconFor, markerBalloonHTML, markerBalloonLayout } from './map.js';
 import { toast } from './ui.js';
+import { haversine } from './utils.js';
 
 const EXPECTED_URL = 'https://script.google.com/macros/s/YOUR_DEPLOYMENT_ID/exec';
 
@@ -43,14 +44,6 @@ export function renderMarkers(items){
     }, { ...markerIconFor(t.key), balloonContentLayout: markerBalloonLayout, hideIconOnBalloonOpen: false });
     window.markersCollection.add(pm);
   });
-}
-
-function haversine(a, b){
-  const R = 6371000; const toRad = d => d*Math.PI/180;
-  const dLat = toRad(b[0]-a[0]); const dLng = toRad(b[1]-a[1]);
-  const s1 = Math.sin(dLat/2), s2 = Math.sin(dLng/2);
-  const c = Math.cos(toRad(a[0]))*Math.cos(toRad(b[0]));
-  return 2*R*Math.asin(Math.sqrt(s1*s1 + c*s2*s2));
 }
 
 export function hasDuplicateNearby(type, coords, meters=25, minutes=15){

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,8 +10,19 @@ function escapeHTML(text) {
   });
 }
 
-export { escapeHTML };
+function haversine(a, b) {
+  const R = 6371000;
+  const toRad = d => d * Math.PI / 180;
+  const dLat = toRad(b[0] - a[0]);
+  const dLng = toRad(b[1] - a[1]);
+  const s1 = Math.sin(dLat / 2);
+  const s2 = Math.sin(dLng / 2);
+  const c = Math.cos(toRad(a[0])) * Math.cos(toRad(b[0]));
+  return 2 * R * Math.asin(Math.sqrt(s1 * s1 + c * s2 * s2));
+}
+
+export { escapeHTML, haversine };
 
 if (typeof module !== 'undefined') {
-  module.exports = { escapeHTML };
+  module.exports = { escapeHTML, haversine };
 }


### PR DESCRIPTION
## Summary
- add haversine distance helper in `src/utils.js`
- reuse haversine in frontend API logic
- load the same helper in backend `code.gs` for consistency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68974308c8e08332bd15cff666b51aae