### PR TITLE
Require explicit CORS origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
    - через поле `YA_MAPS_KEY` объекта `window.MARKER_CONFIG`,
    - либо в мета‑теге `<meta name="ya-maps-key" content="ВАШ_КЛЮЧ">` в `<head>`.
 3. В `index.html` замените `window.MARKER_CONFIG.GAS_ENDPOINT` на URL веб‑приложения Google Apps Script или путь к прокси (например `/server/api/marker_api.php`).
-4. Задайте переменные окружения `MARKER_GAS_ENDPOINT`, `PHOTOS_FOLDER_ID` и `MARKER_ALLOWED_ORIGINS` (см. ниже) или измените их значения в `server/config.php`.
+4. Задайте переменные окружения `MARKER_GAS_ENDPOINT`, `PHOTOS_FOLDER_ID` и обязательную для продакшена `MARKER_ALLOWED_ORIGINS` (см. ниже) или измените их значения в `server/config.php`. Без `MARKER_ALLOWED_ORIGINS` сервер отклоняет запросы.
 5. Запустите встроенный сервер PHP из корня проекта, чтобы одновременно обслуживать статические файлы и API:
 
    ```bash
@@ -50,9 +50,9 @@ export PHOTOS_FOLDER_ID="1CDe78tk-Urh35r0GxMHPVDPt9I-dvvrU"
 export MARKER_ALLOWED_ORIGINS="https://www.bazzarproject.ru,https://bazzarproject.ru,http://localhost:8000"
 ```
 
-`MARKER_GAS_ENDPOINT` — URL Google Apps Script или локального прокси.  
-`PHOTOS_FOLDER_ID` — ID папки Google Drive.  
-`MARKER_ALLOWED_ORIGINS` — разрешённые Origin (через запятую).
+`MARKER_GAS_ENDPOINT` — URL Google Apps Script или локального прокси.
+`PHOTOS_FOLDER_ID` — ID папки Google Drive.
+`MARKER_ALLOWED_ORIGINS` — разрешённые Origin (через запятую). Обязательна в продакшене: без неё сервер вернёт `allowed_origins_not_configured`. В режиме разработки при отсутствии переменной разрешён только `http://localhost:8000`.
 
 ## Локальный запуск и тестирование
 
@@ -84,7 +84,7 @@ export MARKER_ALLOWED_ORIGINS="https://www.bazzarproject.ru,https://bazzarprojec
 ## Серверное API
 
 PHP‑прокси для Google Apps Script теперь расположен в `server/api/marker_api.php`.
-Заголовок `Access-Control-Allow-Origin` больше не жёстко прописан: при отсутствии ограничений возвращается Origin клиента, либо проверяется белый список из `server/config.php` (переменная окружения `MARKER_ALLOWED_ORIGINS`).
+Заголовок `Access-Control-Allow-Origin` проверяется по белому списку из `server/config.php` (переменная окружения `MARKER_ALLOWED_ORIGINS`). При отсутствии настроек сервер вернёт `allowed_origins_not_configured` (в режиме разработки по умолчанию разрешён `http://localhost:8000`).
 
 Прокси передаёт HTTP‑код ответа от Google Apps Script и при сетевых сбоях отдаёт `502` с JSON `{ "ok": false, "error": "..." }`.
 Клиенту следует проверять `response.ok` и поле `ok` в JSON:

--- a/server/api/marker_api.php
+++ b/server/api/marker_api.php
@@ -1,12 +1,18 @@
 <?php
 $config = @include __DIR__ . '/../config.php';
-$allowed = $config['allowed_origins'] ?? array_filter(
-    array_map('trim', explode(',', getenv('MARKER_ALLOWED_ORIGINS') ?: ''))
-);
+$allowed = $config['allowed_origins'] ?? [];
+if (empty($allowed)) {
+  http_response_code(500);
+  header('Content-Type: application/json; charset=UTF-8');
+  echo '{"ok":false,"error":"allowed_origins_not_configured"}';
+  exit;
+}
 $origin = $_SERVER['HTTP_ORIGIN'] ?? '';
-if ($origin && (empty($allowed) || in_array($origin, $allowed, true))) {
+if ($origin === '') {
+  // Same-origin request.
+} elseif (in_array($origin, $allowed, true)) {
   header("Access-Control-Allow-Origin: $origin");
-} elseif (!empty($allowed)) {
+} else {
   http_response_code(403);
   exit;
 }

--- a/server/config.php
+++ b/server/config.php
@@ -2,11 +2,15 @@
 // Configuration values for the Marker API server.
 // Values are primarily sourced from environment variables so that secrets
 // are not committed to the repository.
+// Comma-separated list of origins allowed to access the API.
+$allowed = array_filter(
+    array_map('trim', explode(',', getenv('MARKER_ALLOWED_ORIGINS') ?: ''))
+);
+if (empty($allowed) && PHP_SAPI === 'cli-server') {
+    $allowed = ['http://localhost:8000'];
+}
 return [
-    // Comma-separated list of origins allowed to access the API.
-    'allowed_origins' => array_filter(
-        array_map('trim', explode(',', getenv('MARKER_ALLOWED_ORIGINS') ?: ''))
-    ),
+    'allowed_origins' => $allowed,
     // Google Apps Script endpoint used by the proxy.
     'gas_endpoint' => getenv('MARKER_GAS_ENDPOINT') ?: '',
     // Google Drive folder for uploaded photos.


### PR DESCRIPTION
## Summary
- Fail API requests when no CORS origins are configured
- Add localhost CORS fallback only when running the PHP dev server
- Document MARKER_ALLOWED_ORIGINS requirement for production

## Testing
- `php -l server/config.php`
- `php -l server/api/marker_api.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689746a237688332a18e93f29842f38c