### PR TITLE
Validate marker cache assignment in fetchMarkers

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -24,7 +24,7 @@ export async function fetchMarkers(){
     if (!res.ok) throw new Error(res.status);
     const data = await res.json();
     renderMarkers(Array.isArray(data?.markers) ? data.markers : []);
-    window.__markersCache = data.markers || [];
+    window.__markersCache = Array.isArray(data?.markers) ? data.markers : [];
   } catch(e){
     console.error("fetchMarkers", e);
     toast("Не удалось загрузить метки: " + (e?.message || e));


### PR DESCRIPTION
## Summary
- ensure `fetchMarkers` caches markers only when API returns an array

## Testing
- `npm test`
- manual `fetchMarkers` run with valid marker data
- manual `fetchMarkers` run with invalid marker data

------
https://chatgpt.com/codex/tasks/task_e_689751f37d44833296ee42e7e6454cfc