### PR TITLE
Escape HTML for user profile names

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -75,8 +75,8 @@ export async function renderProfile(){
   }
 
   window.els.profile.innerHTML = `
-      <div class="card"><strong>${prefix ? escapeHTML(prefix) + ' ' : ''}${u?.first_name||'Гость'} ${u?.last_name||''}</strong>
-        <div class="meta">@${u?.username||''}</div>
+      <div class="card"><strong>${prefix ? escapeHTML(prefix) + ' ' : ''}${escapeHTML(u?.first_name || 'Гость')} ${escapeHTML(u?.last_name || '')}</strong>
+        <div class="meta">@${escapeHTML(u?.username || '')}</div>
         <div class="meta">Рейтинг: ${rating}</div>
         <div class="meta">Создано меток: ${markers}</div>
       </div>


### PR DESCRIPTION
## Summary
- escape HTML for first name, last name, and username in `renderProfile`

## Testing
- `npm test`
- `node - <<'NODE' ...` (escapeHTML check for special chars)


------
https://chatgpt.com/codex/tasks/task_e_68975312c08083328dc9f6b9487be077