### PR TITLE
Handle missing config robustly

### DIFF
--- a/server/api/marker_api.php
+++ b/server/api/marker_api.php
@@ -1,6 +1,9 @@
 <?php
 $config = @include __DIR__ . '/../config.php';
-$allowed = $config['allowed_origins'] ?? [];
+if (!is_array($config)) {
+  $config = [];
+}
+$allowed = is_array($config) ? ($config['allowed_origins'] ?? []) : [];
 if (empty($allowed)) {
   http_response_code(500);
   header('Content-Type: application/json; charset=UTF-8');
@@ -20,7 +23,9 @@ header('Access-Control-Allow-Methods: GET,POST,OPTIONS');
 header('Access-Control-Allow-Headers: Content-Type');
 if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') { http_response_code(204); exit; }
 
-$gasEndpoint = $config['gas_endpoint'] ?? getenv('MARKER_GAS_ENDPOINT') ?: '';
+$gasEndpoint = is_array($config)
+  ? ($config['gas_endpoint'] ?? getenv('MARKER_GAS_ENDPOINT') ?: '')
+  : (getenv('MARKER_GAS_ENDPOINT') ?: '');
 if (!$gasEndpoint) {
   http_response_code(500);
   header('Content-Type: application/json; charset=UTF-8');


### PR DESCRIPTION
## Summary
- Ensure marker API handles missing or invalid config arrays
- Safely read `allowed_origins` and `gas_endpoint` from configuration with fallbacks

## Testing
- `php -l server/api/marker_api.php`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897540447dc8332be82f201883b5bb4